### PR TITLE
Fix Supabase function URL

### DIFF
--- a/src/utils/openaiService.ts
+++ b/src/utils/openaiService.ts
@@ -96,7 +96,7 @@ export class OpenAIService {
       const { data: { session } } = await supabase.auth.getSession();
       const token = session?.access_token;
 
-      const response = await fetch(`https://tzgcnaepsjqyoggycncc.supabase.co/functions/v1/chat-completion`, {
+      const response = await fetch(`https://tzgcnaepsjqyoggycncc.functions.supabase.co/functions/v1/chat-completion`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- update the Supabase Edge Function URL to include `.functions` subdomain

## Testing
- `npm run lint` *(fails: no-useless-escape, prefer-const, etc.)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688878f45c648333b7de0d52b5b61d55